### PR TITLE
Fix for py

### DIFF
--- a/AvsAn-Python/AvsAn.py
+++ b/AvsAn-Python/AvsAn.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+
 class AvsAn():
     """
     Singleton class, AvsAn.
@@ -11,20 +12,19 @@ class AvsAn():
     @staticmethod
     def getInstance():
         """ Static access method. """
-        if AvsAn.__instance == None:
+        if AvsAn.__instance is None:
             AvsAn()
         return AvsAn.__instance
 
     def __init__(self):
         """ Virtually private constructor. """
-        if AvsAn.__instance != None:
+        if AvsAn.__instance is not None:
             raise Exception("This class is a singleton!")
         else:
             __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
-            with open(os.path.join(__location__, 'a_vs_an.json')) as f:
+            with open(os.path.join(__location__, 'a_vs_an.json'), encoding="utf8") as f:
 
                 self.root = json.load(f)
-                print("a_vs_an.json was loaded")
             AvsAn.__instance = self
 
     def query(self, word):

--- a/AvsAn-Python/AvsAn_test.py
+++ b/AvsAn-Python/AvsAn_test.py
@@ -2,14 +2,14 @@
 from AvsAn import AvsAn
 
 result = AvsAn.getInstance().query("")
-print result
+print(result)
 result = AvsAn.getInstance().query("x")
-print result
+print(result)
 result = AvsAn.getInstance().query("\"x")
-print result
+print(result)
 result = AvsAn.getInstance().query("unanticipated result")
-print result
+print(result)
 result = AvsAn.getInstance().query("unanimous vote")
-print result
+print(result)
 result = AvsAn.getInstance().query("honest decision")
-print result
+print(result)


### PR DESCRIPTION
This lets the py version run in py 3 without crashing and also sticks to pythonic style guides more closely. Oh and I removed the "a_vs_an.json was loaded" print.